### PR TITLE
Fix #30

### DIFF
--- a/src/lcm/Q_and_F.py
+++ b/src/lcm/Q_and_F.py
@@ -91,7 +91,7 @@ def get_Q_and_F_non_terminal(
 
     # Functions required to calculate the expected continuation values
     state_transition = get_next_state_function(
-        model, next_states=next_state_space_info.states_names, target=Target.SOLVE
+        model=model, next_states=next_state_space_info.states_names, target=Target.SOLVE
     )
     next_stochastic_states_weights = get_next_stochastic_weights_function(
         model, next_stochastic_variables=next_stochastic_variables

--- a/src/lcm/Q_and_F.py
+++ b/src/lcm/Q_and_F.py
@@ -94,7 +94,7 @@ def get_Q_and_F_non_terminal(
         model=model, next_states=next_state_space_info.states_names, target=Target.SOLVE
     )
     next_stochastic_states_weights = get_next_stochastic_weights_function(
-        model, next_stochastic_variables=next_stochastic_variables
+        model, next_stochastic_states=next_stochastic_variables
     )
     joint_weights_from_marginals = _get_joint_weights_function(
         next_stochastic_variables

--- a/src/lcm/dispatchers.py
+++ b/src/lcm/dispatchers.py
@@ -49,6 +49,9 @@ def simulation_spacemap(
         described above but there might be additional dimensions.
 
     """
+    # The model creation process ensures that in a user-created model the following
+    # cannot happen. We double-check here to ensure that the post-processing does not
+    # accidentally create such a situation.
     if duplicates := find_duplicates(actions_names, states_names):
         msg = (
             "Same argument provided more than once in actions or states variables, "

--- a/src/lcm/entry_point.py
+++ b/src/lcm/entry_point.py
@@ -9,10 +9,9 @@ import pandas as pd
 from jax import Array
 
 from lcm.input_processing import process_model
-from lcm.interfaces import StateActionSpace, StateSpaceInfo, Target
+from lcm.interfaces import StateActionSpace, StateSpaceInfo
 from lcm.logging import get_logger
 from lcm.max_Q_over_a import get_argmax_and_max_Q_over_a, get_max_Q_over_a
-from lcm.next_state import get_next_state_function
 from lcm.Q_and_F import (
     get_Q_and_F,
 )
@@ -155,15 +154,10 @@ def get_lcm_function(
         logger=logger,
     )
 
-    _next_state_simulate = get_next_state_function(
-        model=internal_model, target=Target.SIMULATE
-    )
-    next_state_simulate = jax.jit(_next_state_simulate) if jit else _next_state_simulate
     simulate_model = partial(
         simulate,
         argmax_and_max_Q_over_a_functions=argmax_and_max_Q_over_a_functions,
         model=internal_model,
-        next_state=next_state_simulate,
         logger=logger,
     )
 

--- a/src/lcm/input_processing/util.py
+++ b/src/lcm/input_processing/util.py
@@ -102,6 +102,15 @@ def _get_variables_that_enter_concurrent_valuation(
     function_info: pd.DataFrame,
     user_functions: dict[str, UserFunction],
 ) -> list[str]:
+    """Get variables that enter the concurrent valuation.
+
+    The concurrent valuation is the evaluation of the Q_and_F function. Hence, all
+    variables that influence the "utility" (Q), as well as the constraints (F), count
+    as relevant for the concurrent valuation.
+
+    Special variables such as the "_period" or parameters will be ignored.
+
+    """
     enters_Q_and_F_fn_names = [
         "utility",
         *function_info.query("is_constraint").index.tolist(),

--- a/src/lcm/max_Qc_over_d.py
+++ b/src/lcm/max_Qc_over_d.py
@@ -64,7 +64,7 @@ def get_max_Qc_over_d(
 
     """
     if is_last_period:
-        variable_info = variable_info.query("~is_auxiliary")
+        variable_info = variable_info.query("enters_concurrent_valuation")
 
     discrete_action_axes = _determine_discrete_action_axes_solution(variable_info)
 

--- a/src/lcm/next_state.py
+++ b/src/lcm/next_state.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 
 
 def get_next_state_function(
-    model: InternalModel,
     *,
+    model: InternalModel,
     next_states: tuple[str, ...],
     target: Target,
 ) -> Callable[..., dict[str, DiscreteState | ContinuousState]]:

--- a/src/lcm/next_state.py
+++ b/src/lcm/next_state.py
@@ -71,20 +71,20 @@ def get_next_state_function(
 
 def get_next_stochastic_weights_function(
     model: InternalModel,
-    next_stochastic_variables: tuple[str, ...],
+    next_stochastic_states: tuple[str, ...],
 ) -> Callable[..., dict[str, Array]]:
     """Get function that computes the weights for the next stochastic states.
 
     Args:
         model: Internal model instance.
-        next_stochastic_variables: Names of the stochastic variables for which to
-            compute the weights. These variables are relevant for the next state space.
+        next_stochastic_states: Names of the stochastic states for which to compute the
+            weights. These variables are relevant for the next state space.
 
     Returns:
         Function that computes the weights for the next stochastic states.
 
     """
-    targets = [f"weight_next_{name}" for name in next_stochastic_variables]
+    targets = [f"weight_next_{name}" for name in next_stochastic_states]
 
     return concatenate_functions(
         functions=model.functions,

--- a/src/lcm/simulation/processing.py
+++ b/src/lcm/simulation/processing.py
@@ -46,11 +46,14 @@ def process_simulated_data(
     n_periods = len(results)
     n_initial_states = len(results[0].value)
 
+    nan_array = jnp.full(n_initial_states, jnp.nan, dtype=jnp.float64)
+
     list_of_dicts = [
         {"value": d.value, **d.actions, **d.states} for d in results.values()
     ]
     dict_of_lists = {
-        key: [d[key] for d in list_of_dicts] for key in list(list_of_dicts[0])
+        key: [d.get(key, nan_array) for d in list_of_dicts]
+        for key in list(list_of_dicts[0])
     }
     out = {key: jnp.concatenate(values) for key, values in dict_of_lists.items()}
     out["_period"] = jnp.repeat(jnp.arange(n_periods), n_initial_states)

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -91,16 +91,15 @@ def simulate(
 
         is_last_period = period == last_period
 
-        # In the last period, we must remove auxiliary states from the
-        # state-action-space
-        if is_last_period:
-            states_for_state_action_space = {
-                k: v
-                for k, v in states.items()
-                if not model.variable_info.loc[k].is_auxiliary
-            }
-        else:
-            states_for_state_action_space = states
+        relevant_states = model.variable_info.query(
+            "is_state and enters_concurrent_valuation"
+        ).index.tolist()
+        if not is_last_period:
+            relevant_states += model.variable_info.query(
+                "is_state and enters_transition"
+            ).index.tolist()
+
+        states_for_state_action_space = {n: states[n] for n in set(relevant_states)}
 
         state_action_space = create_state_action_space(
             model=model,

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -160,9 +160,9 @@ def simulate(
             states=states,
         )
 
+        # Update states
+        # ------------------------------------------------------------------------------
         if not is_last_period:
-            # Update states
-            # --------------------------------------------------------------------------
             key, stochastic_variables_keys = generate_simulation_keys(
                 key=key,
                 ids=model.function_info.query("is_stochastic_next").index.tolist(),

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -31,37 +31,6 @@ if TYPE_CHECKING:
     )
 
 
-def solve_and_simulate(
-    params: ParamsDict,
-    initial_states: dict[str, Array],
-    argmax_and_max_Q_over_a_functions: dict[int, ArgmaxQOverAFunction],
-    model: InternalModel,
-    next_state: Callable[..., dict[str, Array]],
-    logger: logging.Logger,
-    solve_model: Callable[..., dict[int, FloatND]],
-    *,
-    additional_targets: list[str] | None = None,
-    seed: int | None = None,
-) -> pd.DataFrame:
-    """First solve the model and then simulate the model forward in time.
-
-    Same docstring as `simulate` mutatis mutandis.
-
-    """
-    V_arr_dict = solve_model(params)
-    return simulate(
-        params=params,
-        initial_states=initial_states,
-        argmax_and_max_Q_over_a_functions=argmax_and_max_Q_over_a_functions,
-        model=model,
-        next_state=next_state,
-        logger=logger,
-        V_arr_dict=V_arr_dict,
-        additional_targets=additional_targets,
-        seed=seed,
-    )
-
-
 def simulate(
     params: ParamsDict,
     initial_states: dict[str, Array],

--- a/src/lcm/state_action_space.py
+++ b/src/lcm/state_action_space.py
@@ -39,7 +39,7 @@ def create_state_action_space(
     """
     vi = model.variable_info
     if is_last_period:
-        vi = vi.query("~is_auxiliary")
+        vi = vi.query("enters_concurrent_valuation")
 
     if initial_states is None:
         states = {sn: model.grids[sn] for sn in vi.query("is_state").index}
@@ -82,7 +82,7 @@ def create_state_space_info(
     """
     vi = model.variable_info
     if is_last_period:
-        vi = vi.query("~is_auxiliary")
+        vi = vi.query("enters_concurrent_valuation")
 
     state_names = vi.query("is_state").index.tolist()
 

--- a/tests/input_processing/test_create_params_template.py
+++ b/tests/input_processing/test_create_params_template.py
@@ -33,7 +33,7 @@ class ModelMock:
 def test_create_params_without_shocks(binary_category_class):
     model = ModelMock(
         functions={
-            "f": lambda a, b, c: None,  # noqa: ARG005
+            "utility": lambda a, b, c: None,  # noqa: ARG005
             "next_b": lambda b: b,
         },
         actions={
@@ -45,13 +45,13 @@ def test_create_params_without_shocks(binary_category_class):
         n_periods=None,
     )
     got = create_params_template(model)  # type: ignore[arg-type]
-    assert got == {"beta": jnp.nan, "f": {"c": jnp.nan}, "next_b": {}}
+    assert got == {"beta": jnp.nan, "utility": {"c": jnp.nan}, "next_b": {}}
 
 
 def test_create_function_params():
     model = ModelMock(
         functions={
-            "f": lambda a, b, c: None,  # noqa: ARG005
+            "utility": lambda a, b, c: None,  # noqa: ARG005
         },
         actions={
             "a": None,
@@ -61,7 +61,7 @@ def test_create_function_params():
         },
     )
     got = _create_function_params(model)  # type: ignore[arg-type]
-    assert got == {"f": {"c": jnp.nan}}
+    assert got == {"utility": {"c": jnp.nan}}
 
 
 def test_create_shock_params():

--- a/tests/input_processing/test_process_model.py
+++ b/tests/input_processing/test_process_model.py
@@ -40,12 +40,16 @@ class ModelMock:
 
 @pytest.fixture
 def model(binary_category_class):
+    def utility(c):
+        pass
+
     def next_c(a, b):
-        return a + b
+        pass
 
     return ModelMock(
         n_periods=2,
         functions={
+            "utility": utility,
             "next_c": next_c,
         },
         actions={
@@ -61,11 +65,11 @@ def test_get_function_info(model):
     got = get_function_info(model)
     exp = pd.DataFrame(
         {
-            "is_constraint": [False],
-            "is_next": [True],
-            "is_stochastic_next": [False],
+            "is_constraint": [False, False],
+            "is_next": [False, True],
+            "is_stochastic_next": [False, False],
         },
-        index=["next_c"],
+        index=["utility", "next_c"],
     )
     assert_frame_equal(got, exp)
 
@@ -79,7 +83,8 @@ def test_get_variable_info(model):
             "is_continuous": [False, False],
             "is_discrete": [True, True],
             "is_stochastic": [False, False],
-            "is_auxiliary": [False, True],
+            "enters_concurrent_valuation": [False, True],
+            "enters_transition": [True, False],
         },
         index=["a", "c"],
     )

--- a/tests/simulation/test_simulate.py
+++ b/tests/simulation/test_simulate.py
@@ -8,10 +8,8 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from lcm.entry_point import get_lcm_function
 from lcm.input_processing import process_model
-from lcm.interfaces import Target
 from lcm.logging import get_logger
 from lcm.max_Q_over_a import get_argmax_and_max_Q_over_a
-from lcm.next_state import get_next_state_function
 from lcm.Q_and_F import get_Q_and_F
 from lcm.simulation.simulate import (
     _lookup_optimal_continuous_actions,
@@ -65,7 +63,6 @@ def simulate_inputs():
     return {
         "argmax_and_max_Q_over_a_functions": argmax_and_max_Q_over_a_functions,
         "model": model,
-        "next_state": get_next_state_function(model, target=Target.SIMULATE),
     }
 
 

--- a/tests/test_Q_and_F.py
+++ b/tests/test_Q_and_F.py
@@ -165,7 +165,7 @@ def test_get_combined_constraint_illustrative(internal_model_illustrative):
 
 def test_get_multiply_weights():
     multiply_weights = _get_joint_weights_function(
-        stochastic_variables=["a", "b"],
+        stochastic_variables=("a", "b"),
     )
 
     a = jnp.array([1, 2])

--- a/tests/test_max_Q_over_a.py
+++ b/tests/test_max_Q_over_a.py
@@ -60,7 +60,7 @@ def model_input():
         "state_action_space": state_action_space,
         "state_space_info": state_space_info,
         "next_state": get_next_state_function(
-            model, next_states=("wealth",), target=Target.SOLVE
+            model=model, next_states=("wealth",), target=Target.SOLVE
         ),
         "params": params,
     }

--- a/tests/test_max_Q_over_a.py
+++ b/tests/test_max_Q_over_a.py
@@ -59,7 +59,9 @@ def model_input():
         "model": model,
         "state_action_space": state_action_space,
         "state_space_info": state_space_info,
-        "next_state": get_next_state_function(model, target=Target.SOLVE),
+        "next_state": get_next_state_function(
+            model, next_states=("wealth",), target=Target.SOLVE
+        ),
         "params": params,
     }
 

--- a/tests/test_models/deterministic.py
+++ b/tests/test_models/deterministic.py
@@ -51,19 +51,6 @@ def utility(
     return jnp.log(consumption) - disutility_of_work * working
 
 
-def utility_with_constraint(
-    consumption: ContinuousAction,
-    working: IntND,
-    disutility_of_work: float,
-    # Temporary workaround for bug described in issue #30, which requires us to pass
-    # all state variables to the utility function.
-    # TODO(@timmens): Remove function once #30 is fixed (re-use "utility").
-    # https://github.com/opensourceeconomics/pylcm/issues/30
-    lagged_retirement: DiscreteState,  # noqa: ARG001
-) -> FloatND:
-    return utility(consumption, working, disutility_of_work)
-
-
 # --------------------------------------------------------------------------------------
 # Auxiliary variables
 # --------------------------------------------------------------------------------------
@@ -129,7 +116,7 @@ ISKHAKOV_ET_AL_2017 = Model(
     ),
     n_periods=3,
     functions={
-        "utility": utility_with_constraint,
+        "utility": utility,
         "next_wealth": next_wealth,
         "next_lagged_retirement": next_lagged_retirement,
         "borrowing_constraint": borrowing_constraint,

--- a/tests/test_models/stochastic.py
+++ b/tests/test_models/stochastic.py
@@ -63,11 +63,6 @@ def utility(
     consumption: ContinuousAction,
     working: DiscreteAction,
     health: DiscreteState,
-    # Temporary workaround for bug described in issue #30, which requires us to pass
-    # all state variables to the utility function.
-    # TODO(@timmens): Remove function arguments once #30 is fixed.
-    # https://github.com/opensourceeconomics/pylcm/issues/30
-    partner: DiscreteState,  # noqa: ARG001
     disutility_of_work: float,
 ) -> FloatND:
     return jnp.log(consumption) - (1 - health / 2) * disutility_of_work * working
@@ -87,9 +82,10 @@ def next_wealth(
     wealth: ContinuousState,
     consumption: ContinuousAction,
     labor_income: FloatND,
+    partner: DiscreteState,
     interest_rate: float,
 ) -> ContinuousState:
-    return (1 + interest_rate) * (wealth - consumption) + labor_income
+    return (1 + interest_rate) * (wealth - consumption) + labor_income + partner
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_next_state.py
+++ b/tests/test_next_state.py
@@ -19,7 +19,11 @@ def test_get_next_state_function_with_solve_target():
     model = process_model(
         get_model_config("iskhakov_et_al_2017_stripped_down", n_periods=3),
     )
-    got_func = get_next_state_function(model, target=Target.SOLVE)
+    got_func = get_next_state_function(
+        model,
+        next_states=("wealth",),
+        target=Target.SOLVE,
+    )
 
     params = {
         "beta": 1.0,
@@ -73,7 +77,9 @@ def test_get_next_state_function_with_simulate_target():
         n_periods=1,
     )
 
-    got_func = get_next_state_function(model, target=Target.SIMULATE)
+    got_func = get_next_state_function(
+        model, next_states=("a", "b"), target=Target.SIMULATE
+    )
 
     keys = {"b": jnp.arange(2, dtype="uint32")}
     got = got_func(state=jnp.arange(2), keys=keys, params={})

--- a/tests/test_next_state.py
+++ b/tests/test_next_state.py
@@ -20,7 +20,7 @@ def test_get_next_state_function_with_solve_target():
         get_model_config("iskhakov_et_al_2017_stripped_down", n_periods=3),
     )
     got_func = get_next_state_function(
-        model,
+        model=model,
         next_states=("wealth",),
         target=Target.SOLVE,
     )
@@ -78,7 +78,7 @@ def test_get_next_state_function_with_simulate_target():
     )
 
     got_func = get_next_state_function(
-        model, next_states=("a", "b"), target=Target.SIMULATE
+        model=model, next_states=("a", "b"), target=Target.SIMULATE
     )
 
     keys = {"b": jnp.arange(2, dtype="uint32")}

--- a/tests/test_state_action_space.py
+++ b/tests/test_state_action_space.py
@@ -36,7 +36,7 @@ def test_create_state_action_space_simulation():
     model = process_model(model_config)
     got_space = create_state_action_space(
         model=model,
-        initial_states={
+        states={
             "wealth": jnp.array([10.0, 20.0]),
             "lagged_retirement": jnp.array([0, 1]),
         },
@@ -66,7 +66,7 @@ def test_create_state_action_space_replace():
     model = process_model(model_config)
     space = create_state_action_space(
         model=model,
-        initial_states={
+        states={
             "wealth": jnp.array([10.0, 20.0]),
             "lagged_retirement": jnp.array([0, 1]),
         },

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -120,11 +120,12 @@ def test_compare_deterministic_and_stochastic_results_value_function(model_and_p
     solution_deterministic: dict[int, FloatND] = solve_model_deterministic(params)  # type: ignore[assignment]
     solution_stochastic: dict[int, FloatND] = solve_model_stochastic(params)  # type: ignore[assignment]
 
-    assert jnp.array_equal(
-        jnp.array(list(solution_deterministic.values())),
-        jnp.array(list(solution_stochastic.values())),
-        equal_nan=True,
-    )
+    for period in range(model_deterministic.n_periods):
+        assert jnp.array_equal(
+            solution_deterministic[period],
+            solution_stochastic[period],
+            equal_nan=True,
+        )
 
     # ==================================================================================
     # Compare simulation results

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import jax.numpy as jnp
 import pandas as pd
 import pytest
+from numpy.testing import assert_array_almost_equal
 
 import lcm
 from lcm.entry_point import (
@@ -121,10 +122,10 @@ def test_compare_deterministic_and_stochastic_results_value_function(model_and_p
     solution_stochastic: dict[int, FloatND] = solve_model_stochastic(params)  # type: ignore[assignment]
 
     for period in range(model_deterministic.n_periods):
-        assert jnp.array_equal(
+        assert_array_almost_equal(
             solution_deterministic[period],
             solution_stochastic[period],
-            equal_nan=True,
+            decimal=14,
         )
 
     # ==================================================================================


### PR DESCRIPTION
Fixes #30 by preventing vmap from being applied to variables that aren't function arguments.

Key changes:
- Modified `get_next_state_function()` to accept `next_states` parameter for selective computation
- Updated simulation to only compute relevant states per period based on newly introduced `enters_concurrent_valuation` and `enters_transition` flags for states and actions variables.

---
Closes #30 