### PR TITLE
Fix taste shocks in simulate AOT compilation

### DIFF
--- a/src/_lcm/simulation/compile.py
+++ b/src/_lcm/simulation/compile.py
@@ -345,10 +345,19 @@ def _build_argmax_args(
     subject_states = _subject_shape_arrays(
         base.states, n_subjects=n_subjects, sharding=subject_sharding
     )
+    taste_shock_kwargs = {}
+    if regime.has_taste_shocks:
+        _, taste_shock_keys = generate_simulation_keys(
+            key=jax.random.key(0),
+            names=["taste_shock"],
+            n_initial_states=n_subjects,
+        )
+        taste_shock_kwargs = {"taste_shock_key": taste_shock_keys["key_taste_shock"]}
     return {
         **subject_states,
         **base.discrete_actions,
         **base.continuous_actions,
+        **taste_shock_kwargs,
         "next_regime_to_V_arr": next_regime_to_V_arr,
         **regime_params,
         "period": jnp.int32(period),

--- a/tests/simulation/test_simulate_taste_shocks.py
+++ b/tests/simulation/test_simulate_taste_shocks.py
@@ -111,3 +111,38 @@ def test_taste_shock_draws_are_invariant_to_subject_chunking():
     np.testing.assert_array_equal(
         results[0]["work"].to_numpy(), results[16]["work"].to_numpy()
     )
+
+
+def test_aot_and_lazy_simulation_draw_identical_taste_shock_choices():
+    """AOT and lazy simulation yield the same seeded taste-shock choices."""
+    n_subjects = 16
+    params = taste_shocks_toy.get_params(scale=0.2, discount_factor=0.95)
+    initial_conditions = {
+        "age": jnp.full(n_subjects, 40.0),
+        "wealth": jnp.full(n_subjects, 4.6),
+        "regime_id": jnp.full(
+            n_subjects, taste_shocks_toy.ToyRegimeId.alive, dtype=jnp.int32
+        ),
+    }
+
+    lazy_model = taste_shocks_toy.get_model()
+    period_to_regime_to_V_arr = lazy_model.solve(params=params, log_level="debug")
+    lazy_result = lazy_model.simulate(
+        params=params,
+        initial_conditions=initial_conditions,
+        period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+        log_level="debug",
+        seed=5471,
+    )
+    aot_result = taste_shocks_toy.get_model(n_subjects=n_subjects).simulate(
+        params=params,
+        initial_conditions=initial_conditions,
+        period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+        log_level="debug",
+        seed=5471,
+        max_compilation_workers=1,
+    )
+
+    lazy_work = lazy_result.to_dataframe(use_labels=False).query("period == 0")["work"]
+    aot_work = aot_result.to_dataframe(use_labels=False).query("period == 0")["work"]
+    np.testing.assert_array_equal(aot_work.to_numpy(), lazy_work.to_numpy())

--- a/tests/test_models/taste_shocks_toy.py
+++ b/tests/test_models/taste_shocks_toy.py
@@ -97,11 +97,12 @@ done = UserRegime(
 )
 
 
-def get_model() -> Model:
+def get_model(*, n_subjects: int | None = None) -> Model:
     return Model(
         regimes={"alive": alive, "done": done},
         ages=AgeGrid(start=40, stop=41, step="Y"),
         regime_id_class=ToyRegimeId,
+        n_subjects=n_subjects,
     )
 
 


### PR DESCRIPTION
## Summary

- supply the per-subject taste-shock PRNG-key input while lowering simulation argmax functions for ahead-of-time compilation
- add a public-API regression test asserting identical seeded discrete choices under lazy and AOT simulation
- let the taste-shock toy-model fixture opt into `Model.n_subjects`

## Problem

A model with both `n_subjects` and regime-level taste shocks failed before simulation while lowering the AOT argmax executable:

```text
ValueError: Expected arguments: [..., 'taste_shock_key', ...], missing: {'taste_shock_key'}
```

Runtime simulation already supplied `taste_shock_key`. The AOT argument template omitted the corresponding shaped key.

## Verification

- `pixi run -e tests-cpu pytest tests/simulation/test_simulate_taste_shocks.py tests/simulation/test_simulate_aot.py tests/test_taste_shocks.py tests/test_random.py -q` (35 passed)
- commit-time hooks, including Ruff formatting, Ruff checks, and `ty` (passed)
- repository policy suite reached the long-running solver matrix with no failures before the focused verification run was concluded; CI will run the full matrix
